### PR TITLE
SystemUI: HotspotTile: Don't reset the number of connected clients

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/HotspotTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/HotspotTile.java
@@ -152,7 +152,6 @@ public class HotspotTile extends QSTile<QSTile.AirplaneBooleanState> {
             state.label = mContext.getResources().getQuantityString(
                     R.plurals.wifi_hotspot_connected_clients_label, mNumConnectedClients,
                     mNumConnectedClients);
-            mNumConnectedClients = 0;
         } else {
             state.label = mContext.getString(R.string.quick_settings_hotspot_label);
         }


### PR DESCRIPTION
This seems to be a cherry-pick error, since this line of code wasn't
in the original cm-13.0 commit: 983893dda058bd02a861e732a5e00bec7a414ee8.

This resulted in the hotspot QS tile occasionally displaying
'0 clients' instead of the actual number of clients connected.

Change-Id: I3e7621e4c7ddcde7e1925f0aa8c44d364c706099
Reported-by: Nikolay Jeliazkov <<nijel8@gmail.com>